### PR TITLE
Fix for ZIP file modification on Linux/Unix systems

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/GameUpdater.java
+++ b/src/main/java/org/spoutcraft/launcher/GameUpdater.java
@@ -278,7 +278,7 @@ public class GameUpdater {
 	}
 	
 	public void addFilesToExistingZip(File zipFile, ArrayList<File> files) throws IOException {
-        File tempFile = File.createTempFile(zipFile.getName(), null);
+        File tempFile = File.createTempFile(zipFile.getName(), null, zipFile.getParentFile());
 		tempFile.delete();
 
 		boolean renameOk=zipFile.renameTo(tempFile);


### PR DESCRIPTION
This patch modifies GameUpdater.addFilesToExistingZip() to keep the temporary file in the same directory as the original ZIP file.  File.renameTo() will fail on Linux/Unix systems if the source and destination are not on the same filesystem, which is very likely to happen if you use the default directory that File.createTempFile() gives you (/tmp on Linux).
