### PR TITLE
General UI Bugfix/Improvement

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/Main.java
+++ b/src/main/java/org/spoutcraft/launcher/Main.java
@@ -48,22 +48,22 @@ public class Main {
 			} else {
 				params.add("java"); // Linux/Mac/whatever
 			}
+			if (PlatformUtils.getPlatform() == PlatformUtils.OS.macos) {
+				params.add("-Xdock:name=Spoutcraft");
+				
+				try {
+					File icon = new File(PlatformUtils.getWorkingDirectory(), "icon.icns");
+					GameUpdater.copy(Main.class.getResourceAsStream("/org/spoutcraft/launcher/icon.icns"), new FileOutputStream(icon));
+					params.add("-Xdock:icon=" + icon.getAbsolutePath());
+				}
+				catch (Exception ignore) { }
+			}
 			params.add(memory);
 			params.add("-classpath");
 			params.add(pathToJar);
 			params.add("org.spoutcraft.launcher.Main");
 			for (String arg : args_temp) {
 				params.add(arg);
-			}
-			if (PlatformUtils.getPlatform() == PlatformUtils.OS.macos) {
-				params.add("-Xdock:name=\"Spoutcraft\"");
-				
-				try {
-					File icon = new File(PlatformUtils.getWorkingDirectory(), "icon.icns");
-					GameUpdater.copy(Main.class.getResourceAsStream("/org/spoutcraft/launcher/icon.icns"), new FileOutputStream(icon));
-					params.add("-Xdock:icon=" + icon.getCanonicalPath());
-				}
-				catch (Exception ignore) { }
 			}
 			ProcessBuilder pb = new ProcessBuilder(params);
 			Process process = pb.start();

--- a/src/main/java/org/spoutcraft/launcher/gui/ImageUtils.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/ImageUtils.java
@@ -56,7 +56,7 @@ public class ImageUtils {
 
 		JButton tmp = new JButton(new ImageIcon(resizedImage));
 		tmp.setSelectedIcon(tmp.getIcon());
-		tmp.setDisabledIcon(tmp.getPressedIcon());
+		tmp.setDisabledIcon(tmp.getIcon());
 		tmp.setPressedIcon(tmp.getIcon());
 		
 		tmp.setOpaque(false);

--- a/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
@@ -402,8 +402,8 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 		if ((eventId.equals("Login") || eventId.equals(usernameField.getSelectedItem())) && loginButton.isEnabled()) {
 			doLogin();
 		} else if (eventId.equals("Options")) {
+			options.setBounds((int) getBounds().getCenterX() - 150, (int) getBounds().getCenterY() - 163, 300, 326);
 			options.setVisible(true);
-			options.setBounds((int) getBounds().getCenterX() - 250, (int) getBounds().getCenterY() - 75, 300, 325);
 		} else if (eventId.equals("comboBoxChanged")) {
 			updatePasswordField();
 		}
@@ -440,6 +440,8 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 		this.optionsButton.setEnabled(false);
 		this.loginSkin1.setEnabled(false);
 		this.loginSkin2.setEnabled(false);
+		for(JButton b : loginSkin1Image) b.setEnabled(false);
+		for(JButton b : loginSkin2Image) b.setEnabled(false);
 		options.setVisible(false);
 		SwingWorker<Boolean, Boolean> loginThread = new SwingWorker<Boolean, Boolean>() {
 
@@ -514,6 +516,8 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 				optionsButton.setEnabled(true);
 				loginSkin1.setEnabled(true);
 				loginSkin2.setEnabled(true);
+				for(JButton b : loginSkin1Image) b.setEnabled(true);
+				for(JButton b : loginSkin2Image) b.setEnabled(true);
 				this.cancel(true);
 				return false;
 			}

--- a/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
@@ -402,7 +402,8 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 		if ((eventId.equals("Login") || eventId.equals(usernameField.getSelectedItem())) && loginButton.isEnabled()) {
 			doLogin();
 		} else if (eventId.equals("Options")) {
-			options.setBounds((int) getBounds().getCenterX() - 150, (int) getBounds().getCenterY() - 163, 300, 326);
+			options.setSize(300, 326);
+			options.setLocationRelativeTo(this); //options.setBounds((int) getBounds().getCenterX() - 150, (int) getBounds().getCenterY() - 163, 300, 326);
 			options.setVisible(true);
 		} else if (eventId.equals("comboBoxChanged")) {
 			updatePasswordField();
@@ -628,6 +629,8 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 					optionsButton.setEnabled(true);
 					loginSkin1.setEnabled(true);
 					loginSkin2.setEnabled(true);
+					for(JButton b : loginSkin1Image) b.setEnabled(true);
+					for(JButton b : loginSkin2Image) b.setEnabled(true);
 					this.cancel(true);
 					return false;
 				}
@@ -657,6 +660,8 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 	public void runGame() {
 		LauncherFrame launcher = new LauncherFrame();
 		launcher.setLoginForm(this);
+		launcher.setLocationRelativeTo(this);
+		setVisible(false);
 		int result = launcher.runGame(values[2].trim(), values[3].trim(), values[1].trim(), pass);
 		if (result == LauncherFrame.SUCCESSFUL_LAUNCH) {
 			LoginForm.updateDialog.dispose();
@@ -665,13 +670,18 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 			dispose();
 		}
 		else if (result == LauncherFrame.ERROR_IN_LAUNCH){
+			setVisible(true);
 			loginButton.setEnabled(true);
 			optionsButton.setEnabled(true);
 			loginSkin1.setEnabled(true);
 			loginSkin2.setEnabled(true);
 			progressBar.setVisible(false);
+			for(JButton b : loginSkin1Image) b.setEnabled(true);
+			for(JButton b : loginSkin2Image) b.setEnabled(true);
 		}
-		
+		else {
+			setVisible(true);
+		}
 		this.success = result;
 		//Do nothing for retrying launch
 	}

--- a/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
@@ -403,7 +403,6 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 			doLogin();
 		} else if (eventId.equals("Options")) {
 			options.setSize(300, 326);
-			options.setLocationRelativeTo(this); //options.setBounds((int) getBounds().getCenterX() - 150, (int) getBounds().getCenterY() - 163, 300, 326);
 			options.setVisible(true);
 		} else if (eventId.equals("comboBoxChanged")) {
 			updatePasswordField();


### PR DESCRIPTION
Centered options window on screen and fixed Mac OS X integration issues,
and fixed an issue that allowed the user to click his or her image and
restart the login process.

Changed method of centering Options window to setLocationRelativeTo() to
make code cleaner and easier to change at a later time. On a side note,
I also made it so that the game is launched in the same position as the
startup window (by setting its location in the same way as mentioned
above) and made the launcher window invisible while the game is
launching (because I noticed that if you dragged the game window around
after it is created, but before the Mojang Logo appears, the launcher is
still visible underneath), you may want to remove this code before
merging.
