### PR TITLE
Fixed (accidential) file locking of the SC launcher MD5 process

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/MD5Utils.java
+++ b/src/main/java/org/spoutcraft/launcher/MD5Utils.java
@@ -12,7 +12,10 @@ import org.spoutcraft.launcher.config.YAMLProcessor;
 public class MD5Utils {
 	public static String getMD5(File file){
 		try {
-			return DigestUtils.md5Hex(new FileInputStream(file));
+			FileInputStream fis = new FileInputStream(file);
+			String md5 = DigestUtils.md5Hex(fis);
+			fis.close();
+			return md5;
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
 		} catch (IOException e) {


### PR DESCRIPTION
The SpoutCraft launcher locks files on (some) Windows versions due to not closing the FileInputStream correctly when it performs MD5 sum calculations.
This can lead to issues with updates.
