### PR TITLE
Removed unnecessary caching of library downloads

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/GameUpdater.java
+++ b/src/main/java/org/spoutcraft/launcher/GameUpdater.java
@@ -324,7 +324,7 @@ public class GameUpdater implements DownloadListener {
 				String mirrorURL = "/Libraries/" + lib.getKey() + "/" + name + ".jar";
 				String fallbackURL = "http://dl.getspout.org/Libraries/" + lib.getKey() + "/" + name + ".jar";
 				url = MirrorUtils.getMirrorUrl(mirrorURL, fallbackURL, this);
-				DownloadUtils.downloadFile(url, libraryFile.getPath(), lib.getKey() + ".jar", MD5, this);
+				DownloadUtils.downloadFile(url, libraryFile.getPath(), null, MD5, this);
 			}
 		}
 		


### PR DESCRIPTION
The downloaded library files are cached without reason?!
