### PR TITLE
Added hash checking for the spoutcraft.jar. Removed redundant code out of SpoutcraftBuild

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/GameUpdater.java
+++ b/src/main/java/org/spoutcraft/launcher/GameUpdater.java
@@ -294,7 +294,7 @@ public class GameUpdater implements DownloadListener {
 		}
 		
 		if (!spoutcraft.exists()) {
-			Download download = DownloadUtils.downloadFile(url, updateDir + File.separator + "spoutcraft.jar", null, null, this);
+			Download download = DownloadUtils.downloadFile(url, updateDir + File.separator + "spoutcraft.jar", null, build.getMD5(), this);
 			if (download.isSuccess()) {
 				copy(download.getOutFile(), spoutcraft);
 			}

--- a/src/main/java/org/spoutcraft/launcher/SpoutcraftBuild.java
+++ b/src/main/java/org/spoutcraft/launcher/SpoutcraftBuild.java
@@ -12,12 +12,18 @@ public class SpoutcraftBuild {
 	private int build;
 	Map<String, Object> libraries;
 	private DownloadListener listener = null;
+	private String hash;
 
-	private SpoutcraftBuild(String minecraft, String latest, int build, Map<String, Object> libraries) {
+	private SpoutcraftBuild(String minecraft, String latest, int build, Map<String, Object> libraries, String hash) {
 		this.minecraftVersion = minecraft;
 		this.latestVersion = latest;
 		this.build = build;
 		this.libraries = libraries;
+		this.hash = hash;
+	}
+    
+	public String getMD5() {
+		return hash;
 	}
 
 	public int getBuild() {
@@ -77,17 +83,14 @@ public class SpoutcraftBuild {
 		int recommended = config.getInt("recommended", -1);
 		int selected = SettingsUtil.getSelectedBuild();
 		if (SettingsUtil.isRecommendedBuild()) {
-			Map<String, Object> build = (Map<String, Object>) builds.get(recommended);
-			Map<String, Object> libs = (Map<String, Object>) build.get("libraries");
-			return new SpoutcraftBuild((String)build.get("minecraft"), MinecraftYML.getLatestMinecraftVersion(), recommended, libs);
+			selected = recommended;
 		} else if (SettingsUtil.isDevelopmentBuild()) {
-			Map<String, Object> build = (Map<String, Object>) builds.get(latest);
-			Map<String, Object> libs = (Map<String, Object>) build.get("libraries");
-			return new SpoutcraftBuild((String)build.get("minecraft"), MinecraftYML.getLatestMinecraftVersion(), latest, libs);
+			selected = latest;
 		}
 
 		Map<String, Object> build = (Map<String, Object>) builds.get(selected);
 		Map<String, Object> libs = (Map<String, Object>) build.get("libraries");
-		return new SpoutcraftBuild((String)build.get("minecraft"), MinecraftYML.getLatestMinecraftVersion(), selected, libs);
+		String hash = (String) build.get("hash");
+		return new SpoutcraftBuild((String)build.get("minecraft"), MinecraftYML.getLatestMinecraftVersion(), selected, libs, hash);
 	}
 }


### PR DESCRIPTION
Adds the (apparently missing) MD5 check when downloading spoutcraft.jar (even though the hash is in spoutcraft.yml).
Also fixes some annoyingly redundant code in SpoutcraftBuild.java
