### PR TITLE
Spout relaunch only when needed

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/Options.java
+++ b/src/main/java/org/spoutcraft/launcher/Options.java
@@ -49,6 +49,9 @@ public class Options {
 	@Parameter(names = { "-safe", "-smode", "-safe_mode", "-sm" }, description = "Safe mode preventing addons from loading")
 	private boolean safe_mode = false;
 
+	@Parameter(names = {"-nr", "-norelaunch"}, description = "Don't relaunch the launcher when memory settings are different")
+	private boolean noRelaunch = false;
+	
 	public List<String> getParameters() {
 		return parameters;
 	}
@@ -85,5 +88,9 @@ public class Options {
 
 	public boolean isSafe_mode() {
 		return safe_mode;
+	}
+	
+	public boolean noRelaunch() {
+		return noRelaunch;
 	}
 }


### PR DESCRIPTION
- only relaunches when max memory size is wrong
- added a -norelaunch option for special cases, with an error message
  when size is less then prefered size.

Fixes Jira Issue: http://issues.spout.org/browse/LAUNCHER-10

Signed-off-by: Sir Maniac sir.manic@gmail.com
