### PR TITLE
Added a --skin_class option so that the launcher can load a skin class

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/Main.java
+++ b/src/main/java/org/spoutcraft/launcher/Main.java
@@ -137,7 +137,17 @@ public class Main {
 			start = System.currentTimeMillis();
 		}
 
-		JavaSkin defaultSkin = new DefaultSkin();
+		JavaSkin defaultSkin;
+		if (params.getSkinClass() != null) {
+			try {
+				defaultSkin = Class.forName(params.getSkinClass()).asSubclass(JavaSkin.class).getConstructor().newInstance();
+			} catch (Throwable e) {
+				e.printStackTrace();
+				defaultSkin = new DefaultSkin();
+			}
+		} else {
+			defaultSkin = new DefaultSkin();
+		}
 		launcher.setSkin(defaultSkin);
 		splash.dispose();
 		defaultSkin.getLoginFrame().setVisible(true);

--- a/src/main/java/org/spoutcraft/launcher/StartupParameters.java
+++ b/src/main/java/org/spoutcraft/launcher/StartupParameters.java
@@ -88,6 +88,9 @@ public final class StartupParameters {
 	@Parameter(names = {"-relaunched"}, description = "Used to indicate the process has been relaunched for the property memory arguments")
 	private boolean relaunched = false;
 
+	@Parameter(names = {"-skin_class", "--skin_class"}, description = "Main class name of a custom launcher skin. For testing only.")
+	private String skinClass = null;
+
 	public List<String> getParameters() {
 		return parameters;
 	}
@@ -133,6 +136,9 @@ public final class StartupParameters {
 		}
 		if (relaunched) {
 			log.info("Relaunched with correct memory");
+		}
+		if (skinClass != null) {
+			log.info("Custom launcher skin class specified on command line: " + skinClass);
 		}
 		log.info("--------- End of Startup Parameters ---------");
 	}
@@ -225,6 +231,10 @@ public final class StartupParameters {
 
 	public int getSpoutcraftBuild() {
 		return build;
+	}
+
+	public String getSkinClass() {
+		return skinClass;
 	}
 
 	public void setupProxy() {


### PR DESCRIPTION
A skin class can be specified on the command line, for developing and testing skins.

Example:
java -cp sproutcraft_skin.jar:launcher.jar -jar launcher.jar --skin net.zhuoweizhang.sproutcraftskin.SproutcraftSkin
