### PR TITLE
Fix channel switches to stable if latest is stable

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/SpoutcraftData.java
+++ b/src/main/java/org/spoutcraft/launcher/SpoutcraftData.java
@@ -189,7 +189,6 @@ public final class SpoutcraftData {
 					Project stable = mapper.readValue(stream, Project.class);
 					//Stable release is newer
 					if (stable.getBuild() > build) {
-						Settings.setSpoutcraftChannel(Channel.STABLE);
 						return String.valueOf(stable.getBuild());
 					} else {
 						return String.valueOf(build);


### PR DESCRIPTION
If the latest build is stable and we're on beta/dev, it switches us to stable. Instead it should only download the stable build and keep us at the channel we are at.
Signed-off-by: Steven Downer Grinch@outlook.com
